### PR TITLE
Update JeremyAnsel.HLSL.Targets.targets

### DIFF
--- a/JeremyAnsel.HLSL.Targets/JeremyAnsel.HLSL.Targets/build/JeremyAnsel.HLSL.Targets.targets
+++ b/JeremyAnsel.HLSL.Targets/JeremyAnsel.HLSL.Targets/build/JeremyAnsel.HLSL.Targets.targets
@@ -12,7 +12,7 @@
   <UsingTask TaskName="HLSLShaderCompile" AssemblyFile="..\tools\netstandard2.0\JeremyAnsel.HLSL.Targets.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
   <UsingTask TaskName="HLSLShaderCompile" AssemblyFile="..\tools\net472\JeremyAnsel.HLSL.Targets.dll" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
 
-  <Target Name="HLSLShader" BeforeTargets="Compile">
+  <Target Name="HLSLShader" BeforeTargets="BeforeBuild;Compile">
 
     <ItemGroup>
       <HLSLShader>


### PR DESCRIPTION
The current setup does not allow precompiling HLSL that is embedded into the assembly, since it runs _after_ staging; I'd like to suggest moving the target to an earlier execution point so this workflow may be supported.